### PR TITLE
Fix Error (Xcode): Undefined symbols for Xcode 15, flutter 3.22.1

### DIFF
--- a/ios/facebook_app_events.podspec
+++ b/ios/facebook_app_events.podspec
@@ -22,5 +22,5 @@ Flutter plugin for Facebook Analytics and App Events
   
   # See docs on FBAudienceNetwork
   # https://developers.facebook.com/docs/audience-network/setting-up/platform-setup/ios/add-sdk/
-  s.dependency 'FBAudienceNetwork', '~> 6.15'
+  s.dependency 'FBAudienceNetwork', '6.14'
 end


### PR DESCRIPTION
 - downgrade FBAudienceNetwork to fix Undefined symbols error when building with Xcode 15, flutter 3.22.1

```
Error (Xcode): Undefined symbols:

Error (Xcode): Linker command failed with exit code 1 (use -v to see invocation)

Encountered error while archiving for device.

```

This error occurs when building using following env:
```
$flutter doctor
Doctor summary (to see all details, run flutter doctor -v):
[✓] Flutter (Channel stable, 3.22.1, on macOS 14.4.1 23E224 darwin-arm64, locale en-RO)
[✓] Android toolchain - develop for Android devices (Android SDK version 34.0.0)
[✓] Xcode - develop for iOS and macOS (Xcode 15.0)
[✓] Chrome - develop for the web
[✓] Android Studio (version 2023.3)
[✓] Android Studio (version 2020.3)
[✓] Android Studio (version 2022.3)
[✓] VS Code (version 1.86.0)
[✓] Connected device (4 available)
[✓] Network resources

• No issues found!

```

